### PR TITLE
fix: add User model in prisma for generate without errors

### DIFF
--- a/src/utils/createProject.js
+++ b/src/utils/createProject.js
@@ -140,6 +140,16 @@ datasource db {
   provider = "${dbProvider}"
   url      = env("DATABASE_URL")
 }
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String?
+  password  String
+  role      String   @default("user")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
 `;
       await fs.writeFile(path.join(projectPath, 'prisma', 'schema.prisma'), prismaSchema);
     }


### PR DESCRIPTION
## 🛠 Description
This PR fixes generation errors by adding the missing `User` model to the Prisma schema. Without this model, the `npx prisma generate` command may fail if other parts of the application or generators expect a base user entity.

## 📝 Changes
* Added `User` model to `schema.prisma`.
* Implemented **UUID** for the primary key.
* Included `email` (unique), `password`, and `role` (default: "user").
* Added `createdAt` and `updatedAt` timestamps for data auditing.

## 💻 Schema Added
```prisma
model User {
  id        String   @id @default(uuid())
  email     String   @unique
  name      String?
  password  String
  role      String   @default("user")
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
}